### PR TITLE
Fix Gradle build config and add ViewModel tests

### DIFF
--- a/AndroidApp/app/build.gradle
+++ b/AndroidApp/app/build.gradle
@@ -1,7 +1,5 @@
-plugins {
-    id 'com.android.application'
-    id 'kotlin-android'
-}
+apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
 
 android {
     compileSdk 33
@@ -30,4 +28,5 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
     implementation 'net.openvpn:openvpn:0.7.1'
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/AndroidApp/app/src/test/java/com/example/vpn/VpnViewModelTest.kt
+++ b/AndroidApp/app/src/test/java/com/example/vpn/VpnViewModelTest.kt
@@ -1,0 +1,26 @@
+import org.junit.Assert.*
+import org.junit.Test
+
+class VpnViewModelTest {
+    @Test
+    fun invalidIndexReturnsError() {
+        val vm = VpnViewModel()
+        val result = kotlinx.coroutines.runBlocking { vm.connect(0, "/tmp/nonexist.ovpn") }
+        assertEquals("Invalid host index", result)
+    }
+
+    @Test
+    fun missingPathReturnsError() {
+        val vm = VpnViewModel()
+        vm.javaClass.getDeclaredField("hostNames").apply {
+            isAccessible = true
+            (get(vm) as MutableList<String>).add("test")
+        }
+        vm.javaClass.getDeclaredField("hostMap").apply {
+            isAccessible = true
+            (get(vm) as MutableMap<String, String>)["test"] = "1.2.3.4"
+        }
+        val result = kotlinx.coroutines.runBlocking { vm.connect(0, null) }
+        assertEquals("OVPN path required", result)
+    }
+}


### PR DESCRIPTION
## Summary
- apply Android and Kotlin plugins using the older `apply plugin` syntax
- add missing JUnit dependency
- create basic unit tests for `VpnViewModel`

## Testing
- `gradle -p AndroidApp projects` *(fails: Could not resolve gradle plugin due to network)*
- `gradle -p AndroidApp test --no-daemon` *(fails: Could not resolve gradle plugin due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685eebac8f688327955c43f7374bfd46